### PR TITLE
fix: comment out drop_duplicates call

### DIFF
--- a/scripts/update-bikeways.py
+++ b/scripts/update-bikeways.py
@@ -926,9 +926,6 @@ def process_data(
     # Add length column
     bf_all_processed.spatial.set_geometry('SHAPE')
     bf_all_processed['LENGTH'] = GeoSeriesAccessor(bf_all_processed['SHAPE']).length
-
-    # dropping duplicated roads with the same length and attributes
-    # bf_all_processed = bf_all_processed.drop_duplicates(['CARTOCODE','FULLNAME', 'BIKE_L', 'BIKE_R', 'BIKE_PLN_L', 'BIKE_PLN_R',  'SPEED_LMT', 'CITY', 'COUNTY', 'LENGTH'] , keep='first')
     
     bf_all_processed.spatial.to_featureclass(
         location=os.path.join(scratch_gdb, "bf_all_processed"), sanitize_columns=False


### PR DESCRIPTION
I commented out the line with a pandas 'drop_duplicates' call.  This seems to be causing data dropouts where street segments disappear because they have the same attributes and length.  The issue was mostly clearly seen in the Avenues area.

After removing this line, the data seemed to rebuild and publish as expected.  There is an arcpy 'DeleteIdentical' call later on that should deduplicate segments with identical geometires.